### PR TITLE
Cleanup named links

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,6 @@
 # OpenJS Cross Project Council
 
-For the current list of Team members, see the project
-[README.md](./README.md).
+For the current list of Team members, see the project [README.md][README].
 
 ## Members
 
@@ -67,11 +66,10 @@ Members participate in a vote.
 
 ## Term for voting members
 
-As per the CPC charter, the term for all voting members is normally 1 year.
+As per the [CPC charter][cpc charter term], the term for all voting members is normally 1 year:
 
-From: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members
 > Voting members serve for a term of 1 year and must be re-nominated and ratified
-  by the Voting CPC members each year.
+> by the Voting CPC members each year.
 
 Due to the bootstrap process, the term for the first year will be
 shortened such that the initial term for all voting members ends March 31st, 2020.
@@ -79,7 +77,7 @@ Subsequent terms wil be for a period of 1 year ending the following March 31st.
 
 ## Election process for Non-Impact Voting CPC members
 
-As per the [CPC charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md), the non-impact projects elect 2 voting CPC members:
+As per the [CPC charter][cpc charter], the non-impact projects elect 2 voting CPC members:
 
 > up to two (2) Voting members may be nominated by the non-impact projects based on a process set by the CPC.
 
@@ -118,9 +116,9 @@ These members will be elected for a term of 1 year as follows:
 ## Approving and Onboarding Regular Members
 
 Regular members can self-nominate by opening a PR to add themselves to the Regular
-member list in the [README.md](https://github.com/openjs-foundation/cross-project-council/blob/master/README.md). 
+member list in the [README.md][README].
 The PR should include an indication of which project they have been active in for
-3 months as per the [CPC charter](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#regular-members).
+3 months as per the [CPC charter][cpc charter regular members].
 
 The PR to add a regular member is approved when:
 
@@ -132,12 +130,12 @@ Once a PR is ready to be landed, the CPC member who lands the pull request shoul
 
 * Send a notification to the project contacts for the project identified in the PR
   indicating that a new regular CPC member has joined the CPC on behalf of the project.
-* Add the member to the github `cpc-regular-members` [team](https://github.com/orgs/openjs-foundation/teams/cpc-regular-members)
+* Add the member to the github `cpc-regular-members` [team][cpc regular members team]
 * Introduce the new member at the next CPC meeting.
 
 ## Aproving Project Charters
 
-Per the [CPC charter section 5](https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc), the voting CPC members are responsible for approving project
+Per the [CPC charter section 5][], the voting CPC members are responsible for approving project
 charters and changes to them.
 
 Approval of the initial charter or changes to an existing charter will
@@ -195,3 +193,10 @@ If someone disagrees with the fast-tracking request, remove the label. Do not fa
 The pull request may be fast-tracked if two CPC members approve the fast-tracking request. To land, the pull request itself still needs two CPC member approvals.
 
 CPC members may request fast-tracking of pull requests they did not author. In that case only, the request itself is also one fast-track approval. Upvote the comment anyway to avoid any doubt.
+
+[cpc charter]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md
+[cpc charter term]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#voting-members
+[CPC charter section 5]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#section-5-responsibilities-and-expectations-of-the-cpc
+[cpc charter regular members]: https://github.com/openjs-foundation/cross-project-council/blob/master/CPC-CHARTER.md#regular-members
+[cpc regular members team]: https://github.com/orgs/openjs-foundation/teams/cpc-regular-members
+[README]: ./README.md

--- a/transfer-repo-into-org.md
+++ b/transfer-repo-into-org.md
@@ -21,8 +21,9 @@ so they can ping the relevant GitHub teams to discuss the request.
 If the person who wants to initiate the request is not a member, they could ask
 an existing member to open the issue._
 
-Go to [the issue tracker of the Cross Project Council repository][issue tracker], open an issue
-to request moving the repository into the organization. The issue should include:
+Go to [the issue tracker of the Cross Project Council repository][cpc issue tracker],
+open an issue to request moving the repository into the organization.
+The issue should include:
 
 - The owner and the name of the repository, and a link to it.
 - What the repository is for, why it should be transferred into the organization.

--- a/transfer-repo-into-org.md
+++ b/transfer-repo-into-org.md
@@ -5,11 +5,11 @@
 Ideally, the repository should have the following documents in place:
 
 - `CODE_OF_CONDUCT.md`: it can be a reference to
-  [the OpenJS Foundation's Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md).
-- `CONTRIBUTING.md`: if there isn't one already, [the contributing guide](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md)
-  of Node.js core could be a good example. Consider including the Developer's
-  Certificate of Origin section in the document to avoid potential copyright
-  conflicts.
+  [the OpenJS Foundation's Code of Conduct][coc].
+- `CONTRIBUTING.md`: if there isn't one already, Node.js core's 
+  [contributing guide][Node.js core contributing] could be a good example.
+  Consider including the Developer's Certificate of Origin section in the
+  document to avoid potential copyright conflicts.
 - `LICENSE`, or other kind of documents that describe the license of
   the project.
 - `README.md`
@@ -21,7 +21,7 @@ so they can ping the relevant GitHub teams to discuss the request.
 If the person who wants to initiate the request is not a member, they could ask
 an existing member to open the issue._
 
-Go to [the issue tracker of the Cross Project Council repository](https://github.com/openjs-foundation/cross-project-council/issues), open an issue
+Go to [the issue tracker of the Cross Project Council repository][issue tracker], open an issue
 to request moving the repository into the organization. The issue should include:
 
 - The owner and the name of the repository, and a link to it.
@@ -29,7 +29,8 @@ to request moving the repository into the organization. The issue should include
 - Mention `@openjs-foundation/cpc` so the Cross Project Council members can be
   notified about the request and weigh in.
 
-See the [OpenJS Foundation GitHub Organization Management Policy](https://github.com/openjs-foundation/cross-project-council/blob/master/GITHUB_ORG_MANGEMENT_POLICY.md) on how the request is approved.
+See the [OpenJS Foundation GitHub Organization Management Policy][github org mgmt]
+on how the request is approved.
 
 ## Step 3. Transfer the repository
 
@@ -38,7 +39,7 @@ the repository into the OpenJS GitHub organization. The person can be made a
 member of the OpenJS GitHub organization so they have the necessary permissions
 to complete the transfer.
 
-See [GitHub's documentation on transferring repos](https://help.github.com/articles/about-repository-transfers/) on how to perform the
+See [GitHub's documentation on transferring repos][how to transfer] on how to perform the
 necessary actions.
 
 ## Step 4. Manage releases
@@ -52,8 +53,8 @@ The releases should still by done by the original releasers.
 See [NPM Management](./npm-management.md) on more about the Node.js foundation
 npm account.
 
-[coc]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
-[GitHub's documentation on transferring repos]: https://help.github.com/articles/about-repository-transfers/
-[Node.js GitHub Organization Management Policy]: https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANGEMENT_POLICY.md#repositories
-[the contributing guide]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-[the issue tracker of the Node.js admin repository]: https://github.com/nodejs/admin/issues
+[coc]: https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md
+[how to transfer]: https://help.github.com/articles/about-repository-transfers/
+[github org mgmt]: https://github.com/openjs-foundation/cross-project-council/blob/master/GITHUB_ORG_MANGEMENT_POLICY.md
+[Node.js core contributing]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
+[cpc issue tracker]: https://github.com/openjs-foundation/cross-project-council/issues


### PR DESCRIPTION
There were a number of named links at the bottom that pointed to Node.js equivalents.

Replaced inline URLs with named links, cleaned up the named links to separate them from the document text, and got rid of redundant named links.